### PR TITLE
Small QOL improvements

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,10 @@
+import datetime
 import streamlit as st
 import backend as be
 
 def main():
+    st.set_page_config(page_title="Behavioural analysis pipeline", page_icon="🧠", layout="wide", initial_sidebar_state="auto", 
+                       menu_items={"Last deployment": f'{datetime.datetime.now()}'})
     st.title("Behavioural analysis pipeline")
     st.divider()
     st.header("Welcome to the behavioural analysis pipeline!")

--- a/backend.py
+++ b/backend.py
@@ -36,7 +36,8 @@ def get_bouts(df: pd.DataFrame) -> pd.DataFrame:
     tree = IntervalTree(Interval(start, stop) for start, stop in zip(df['Time_start'], df['Time_stop']))
 
     tree.merge_overlaps()
-    intervals_df = pd.DataFrame([(interval.begin, interval.end, i+1) for i, interval in enumerate(tree)], columns=['Time_start', 'Time_stop', 'bout_id'])
+    sorted_tree = sorted(tree, key=lambda x: x.begin)
+    intervals_df = pd.DataFrame([(interval.begin, interval.end, i+1) for i, interval in enumerate(sorted_tree)], columns=['Time_start', 'Time_stop', 'bout_id'])
     df['bout_id'] = np.nan
 
     for i, row in df.iterrows():


### PR DESCRIPTION
This PR:
- sorts the interval tree so that bout ids are based on bout start time
- adds an `About` section that includes last deploy date so I can more easily monitor that it's working as expected